### PR TITLE
mimic the original flags, more flags, inc support for >1 connected Jlink

### DIFF
--- a/nrfjprog.sh
+++ b/nrfjprog.sh
@@ -8,15 +8,15 @@ which relies on JLinkExe to interface with the JLink hardware.
 
 usage:
 
-nrfjprog.sh <action> [hexfile]
+nrfjprog.sh <action> [action paramters]
 
 where action is one of
   --info
   --reset
   --pin-reset
   --erase-all
-  --flash
-  --flash-softdevice
+  --flash               <hexfile>
+  --flash-softdevice    <hexfile>
   --rtt
   --gdbserver
 
@@ -26,74 +26,168 @@ GREEN="\033[32m"
 RESET="\033[0m"
 STATUS_COLOR=$GREEN
 
+
 TOOLCHAIN_PREFIX=arm-none-eabi
 # assume the tools are on the system path
 TOOLCHAIN_PATH=
-JLINK_OPTIONS="-device nRF52 -if SWD -speed 4000"
+JLINK="JLinkExe"
+JLINKGDBSERVER="JLinkGDBServer"
+JLINKRTTSERVER=JLinkRTTServer
+JLINKRTTCLIENT=JLinkRTTClient
 
-HEX=$2
-
-JLINK="JLinkExe $JLINK_OPTIONS"
-JLINKGDBSERVER="JLinkGDBServer $JLINK_OPTIONS"
+# Defaults
+DEVICE="nRF52"
+IF="SWD"
+SPEED="4000"
+EMUSERIAL=""
 GDB_PORT=2331
+
+
+
+function msg {
+    echo ""
+    echo -e "${STATUS_COLOR}${1}${RESET}"
+    echo ""
+}
+
+
+# As long as there is at least one more argument, keep looping
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case "$key" in
+        -f|--family)
+        shift
+        DEVICE=$1
+        ;;
+        -p|--port)
+        shift
+        GDB_PORT="$1"
+        ;;
+        -c|--clockspeed)
+        shift
+        SPEED="$1"
+        ;;
+        -s|--snr)
+        shift
+        EMUSERIAL=$1
+        ;;
+        -e|--erase-all)
+        CMD="erase-all"
+        ;;
+        -i|--ids)
+        CMD="showserials"
+        ;;
+        -r|--reset)
+        CMD="reset"
+        ;;
+        -R|--pinreset---pin-reset)
+        CMD="pinreset"
+        ;;
+        -f|--flash|--program)
+        shift
+        CMD="flash"
+        HEX="$1"
+        ;;
+        -F|--flash-softdevice)
+        shift
+        CMD="flash-softdevice"
+        HEX="$1"
+        ;;
+        -t|--rtt)
+        CMD="rtt"
+        ;;
+        -g|--gdbserver)
+        CMD="gdbserver"
+        ;;
+        -p|--port)
+        shift
+        GDB_PORT="$1"
+        ;;
+        # This is an arg=value type option. Will catch -o=value or --output-file=value
+        -o=*|--output-file=*)
+        # No need to shift here since the value is part of the same string
+        OUTPUTFILE="${key#*=}"
+        ;;
+        *)
+        # Do whatever you want with extra options
+        echo "Unknown option '$key'"
+        ;;
+    esac
+    # Shift after checking all the cases to get the next option
+    shift
+done
+
+
+echo CMD=$CMD
+echo DEVICE=$DEVICE
+echo EMUSERIAL=$EMUSERIAL
+echo HEX=$HEX
+
 
 # the script commands come from Makefile.posix, distributed with
 # nrf51-pure-gcc. I've made some changes to use hexfiles instead of binfiles
 
 TMPSCRIPT=/tmp/tmp_$$.jlink
-if [ "$1" = "--info" ]; then
-    echo "connect" > $TMPSCRIPT
-    echo "exit" >> $TMPSCRIPT
-    $JLINK $TMPSCRIPT
+
+touch $TMPSCRIPT
+
+if [ "$EMUSERIAL" ]; then
+    echo "SelectEmuBySN $EMUSERIAL" >> $TMPSCRIPT
+fi
+
+echo "device $DEVICE" >> $TMPSCRIPT
+echo "if $IF" >> $TMPSCRIPT
+echo "speed $SPEED" >> $TMPSCRIPT
+
+function runscript {
+    $JLINK < $TMPSCRIPT
     rm $TMPSCRIPT
-elif [ "$1" = "--reset" ]; then
-    echo ""
-    echo -e "${STATUS_COLOR}resetting...${RESET}"
-    echo ""
-    echo "r" > $TMPSCRIPT
+}
+
+if [ "$CMD" = "info" ]; then
+    echo "connect" >> $TMPSCRIPT
+    echo "exit" >> $TMPSCRIPT
+    runscript
+elif [ "$CMD" = "showserials" ]; then
+    echo "showemulist usb" >> $TMPSCRIPT
+    echo "exit" >> $TMPSCRIPT
+    runscript
+elif [ "$CMD" = "reset" ]; then
+    echo resetting...
+    echo "r" >> $TMPSCRIPT
     echo "g" >> $TMPSCRIPT
     echo "exit" >> $TMPSCRIPT
-    $JLINK $TMPSCRIPT
-    rm $TMPSCRIPT
-elif [ "$1" = "--pin-reset" ]; then
-    echo ""
-    echo -e "${STATUS_COLOR}resetting with pin...${RESET}"
-    echo ""
-    echo "w4 40000544 1" > $TMPSCRIPT
+    runscript
+elif [ "$CMD" = "pinreset" ]; then
+    echo resetting with pin...
+    echo "w4 40000544 1" >> $TMPSCRIPT
     echo "r" >> $TMPSCRIPT
     echo "exit" >> $TMPSCRIPT
-    $JLINK $TMPSCRIPT
-    rm $TMPSCRIPT
-elif [ "$1" = "--erase-all" ]; then
+    runscript
+elif [ "$CMD" = "erase-all" ]; then
     echo ""
-    echo -e "${STATUS_COLOR}perfoming full erase...${RESET}"
+    msg perfoming full erase...
     echo ""
-    echo "h" > $TMPSCRIPT
+    echo "h" >> $TMPSCRIPT
     echo "w4 4001e504 2" >> $TMPSCRIPT
     echo "w4 4001e50c 1" >> $TMPSCRIPT
     echo "sleep 100" >> $TMPSCRIPT
     echo "r" >> $TMPSCRIPT
     echo "exit" >> $TMPSCRIPT
-    $JLINK $TMPSCRIPT
-    rm $TMPSCRIPT
-elif [ "$1" = "--flash" ]; then
-    echo ""
-    echo -e "${STATUS_COLOR}flashing ${HEX}...${RESET}"
-    echo ""
-    echo "r" > $TMPSCRIPT
+    runscript
+elif [ "$CMD" = "flash" ]; then
+    msg flashing ${HEX}...
+    echo "r" >> $TMPSCRIPT
     echo "h" >> $TMPSCRIPT
     echo "loadfile $HEX" >> $TMPSCRIPT
     echo "r" >> $TMPSCRIPT
     echo "g" >> $TMPSCRIPT
     echo "exit" >> $TMPSCRIPT
-    $JLINK $TMPSCRIPT
-    rm $TMPSCRIPT
-elif [ "$1" = "--flash-softdevice" ]; then
-    echo ""
-    echo -e "${STATUS_COLOR}flashing softdevice ${HEX}...${RESET}"
-    echo ""
+    runscript
+elif [ "$CMD" = "flash-softdevice" ]; then
+    echo flashing softdevice ${HEX}...
     # Halt, write to NVMC to enable erase, do erase all, wait for completion. reset
-    echo "h"  > $TMPSCRIPT
+    echo "h"  >> $TMPSCRIPT
     echo "w4 4001e504 2" >> $TMPSCRIPT
     echo "w4 4001e50c 1" >> $TMPSCRIPT
     echo "sleep 100" >> $TMPSCRIPT
@@ -105,9 +199,8 @@ elif [ "$1" = "--flash-softdevice" ]; then
     echo "r" >> $TMPSCRIPT
     echo "g" >> $TMPSCRIPT
     echo "exit" >> $TMPSCRIPT
-    $JLINK $TMPSCRIPT
-    rm $TMPSCRIPT
-elif [ "$1" = "--rtt" ]; then
+    runscript
+elif [ "$CMD" = "rtt" ]; then
     # trap the SIGINT signal so we can clean up if the user CTRL-C's out of the
     # RTT client
     trap ctrl_c INT
@@ -115,16 +208,16 @@ elif [ "$1" = "--rtt" ]; then
         return
     }
     echo -e "${STATUS_COLOR}Starting RTT Server...${RESET}"
-    JLinkExe -device nrf51822 -if swd -speed 1000 &
+    $JLINKRTTSERVER -device $DEVICE -if $IF -speed $SPEED &
     JLINK_PID=$!
     sleep 1
     echo -e "\n${STATUS_COLOR}Connecting to RTT Server...${RESET}"
     #telnet localhost 19021
-    JLinkRTTClient
+    $JLINKRTTCLIENT
     echo -e "\n${STATUS_COLOR}Killing RTT server ($JLINK_PID)...${RESET}"
     kill $JLINK_PID
-elif [ "$1" = "--gdbserver" ]; then
-    $JLINKGDBSERVER -port $GDB_PORT
+elif [ "$CMD" = "gdbserver" ]; then
+    $JLINKGDBSERVER -port $GDB_PORT  -device $DEVICE -if $IF -speed $SPEED
 else
     echo "$USAGE"
 fi


### PR DESCRIPTION
Supports the latest version of JLink that slurps the command script from stdin, old method no longer works (AFAIR when I did this, was a few months ago.)

Added flags for device, interface, speed and serial (therefore supports >1 attached JLink)